### PR TITLE
新規にコメント一件を作成し、配列に追加するメソッドの作成

### DIFF
--- a/models/Comment.js
+++ b/models/Comment.js
@@ -31,6 +31,9 @@ module.exports = {
     if (!username) {
       throw new Error('usernameは必須です');
     }
+    if (!body) {
+      throw new Error('bodyは必須です');
+    }
 
     const comment = new Comment({
       username: username,

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -41,5 +41,7 @@ module.exports = {
     });
 
     comments.push(comment);
+
+    return comment;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -27,4 +27,8 @@ module.exports = {
   findAll: () => {
     return comments;
   },
+  createComment: ({ username, body }) => {
+    username;
+    body;
+  },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -25,7 +25,7 @@ for (let i = 0; i < 3; i++) {
 
 module.exports = {
   findAll: () => {
-    return comments;
+    return comments.slice();
   },
   createComment: ({ username, body }) => {
     if (!username) {

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -28,7 +28,15 @@ module.exports = {
     return comments;
   },
   createComment: ({ username, body }) => {
-    username;
-    body;
+    if (!username) {
+      throw new Error('usernameは必須です');
+    }
+
+    const comment = new Comment({
+      username: username,
+      body: body,
+    });
+
+    comments.push(comment);
   },
 };

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -3,3 +3,8 @@ const Comment = require('../../models/Comment');
 
 assert;
 Comment;
+describe('Comment.createCommentメソッドの作成', () => {
+  it('Comment.createCommentはメソッドである', () => {
+    assert.equal(typeof Comment.createComment, 'function');
+  });
+});

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -1,8 +1,6 @@
 const assert = require('power-assert');
 const Comment = require('../../models/Comment');
 
-assert;
-Comment;
 describe('Comment.createCommentメソッドの作成', () => {
   it('Comment.createCommentはメソッドである', () => {
     assert.equal(typeof Comment.createComment, 'function');

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -7,7 +7,7 @@ describe('Comment.createCommentメソッドの作成', () => {
   it('Comment.createCommentはメソッドである', () => {
     assert.equal(typeof Comment.createComment, 'function');
   });
-  it('usernameにプロパティ値が入ってない場合エラーが返される', () => {
+  it('usernameの引数に値が入ってない場合エラーが返される', () => {
     const dataList = [{}, { body: 'test body' }];
 
     dataList.forEach(data => {
@@ -19,12 +19,31 @@ describe('Comment.createCommentメソッドの作成', () => {
       }
     });
   });
-  it('bodyにプロパティ値が入ってない場合エラーが返される', () => {
+  it('bodyの引数に値が入ってない場合エラーが返される', () => {
     try {
       Comment.createComment({ username: 'test username' });
       assert.fail();
     } catch (error) {
       assert.equal(error.message, 'bodyは必須です');
     }
+  });
+  it('適切なデータを渡した際、新規にコメントを1件作成して、そのコメント一件を返す、配列には新たなコメントが1件入っている', () => {
+    const oldComments = Comment.findAll();
+    const data = {
+      username: 'test username',
+      body: 'test body',
+    };
+
+    const newComment = Comment.createComment(data);
+    assert.deepEqual(newComment, {
+      id: data.id,
+      username: data.username,
+      body: data.body,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    });
+
+    const currentComments = Comment.findAll();
+    assert.equal(oldComments.length + 1, currentComments.length);
   });
 });

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -36,11 +36,11 @@ describe('Comment.createCommentメソッドの作成', () => {
 
     const newComment = Comment.createComment(data);
     assert.deepEqual(newComment, {
-      id: data.id,
-      username: data.username,
-      body: data.body,
-      createdAt: data.createdAt,
-      updatedAt: data.updatedAt,
+      id: newComment.id,
+      username: newComment.username,
+      body: newComment.body,
+      createdAt: newComment.createdAt,
+      updatedAt: newComment.updatedAt,
     });
 
     const currentComments = Comment.findAll();

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -35,8 +35,8 @@ describe('Comment.createCommentメソッドの作成', () => {
     const newComment = Comment.createComment(data);
     assert.deepEqual(newComment, {
       id: newComment.id,
-      username: newComment.username,
-      body: newComment.body,
+      username: data.username,
+      body: data.body,
       createdAt: newComment.createdAt,
       updatedAt: newComment.updatedAt,
     });

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -1,0 +1,5 @@
+const assert = require('power-assert');
+const Comment = require('../../models/Comment');
+
+assert;
+Comment;

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -7,4 +7,16 @@ describe('Comment.createCommentメソッドの作成', () => {
   it('Comment.createCommentはメソッドである', () => {
     assert.equal(typeof Comment.createComment, 'function');
   });
+  it('usernameにプロパティ値が入ってない場合エラーが返される', () => {
+    const dataList = [{}, { body: 'test body' }];
+
+    dataList.forEach(data => {
+      try {
+        Comment.createComment(data);
+        assert.fail();
+      } catch (error) {
+        assert.equal(error.message, 'usernameは必須です');
+      }
+    });
+  });
 });

--- a/test/models/createComment.test.js
+++ b/test/models/createComment.test.js
@@ -19,4 +19,12 @@ describe('Comment.createCommentメソッドの作成', () => {
       }
     });
   });
+  it('bodyにプロパティ値が入ってない場合エラーが返される', () => {
+    try {
+      Comment.createComment({ username: 'test username' });
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'bodyは必須です');
+    }
+  });
 });


### PR DESCRIPTION
# createCommentメソッドの作成

メソッドの機能として、README.mdに記載されている
> 「POST /api/comments」「PUT /api/comments/:id」を実行する際は、username、 bodyの送信を必須とする。

決まりに乗っ取り、model側でエラーを出し、`username`、`body`共に適切な値が入っている場合のみメソッドが成功するようにコーディングしました

# createCommentメソッドのテスト

試しにTDDスタイルでテストを行なってみました

## テスト内容

1. `Comment.createComment`はメソッドである
2. `username`の引数に値が入ってない場合エラーが返される
3.  `body`の引数に値が入ってない場合エラーが返される
4.  適切なデータを渡した際、新たにコメントを一件作成し、そのコメント一件は返される
5. `4.`と同時に、`Comment.findAll`で返される配列には`4.`で作成したコメント一件が入っている