### PR TITLE
指定したid値と合致したコメントの情報を更新して、そのコメントを返すメソッドの作成

### DIFF
--- a/models/Comment.js
+++ b/models/Comment.js
@@ -40,6 +40,8 @@ module.exports = {
     if (!username) {
       throw new Error('usernameは必須です');
     }
-    body;
+    if (!body) {
+      throw new Error('bodyは必須です');
+    }
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -33,6 +33,10 @@ module.exports = {
         'idに適切でない値が入っています、1以上の数字を入れてください'
       );
     }
+    const comment = comments.find(comment => id === comment.id);
+    if (!comment) {
+      throw new Error('idと合致するCommentが見つかりません');
+    }
     username;
     body;
   },

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -28,7 +28,11 @@ module.exports = {
     return comments;
   },
   updateComment: ({ id, username, body }) => {
-    id;
+    if (typeof id !== 'number' || id < 1) {
+      throw new Error(
+        'idに適切でない値が入っています、1以上の数字を入れてください'
+      );
+    }
     username;
     body;
   },

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -47,6 +47,7 @@ module.exports = {
     comment.username = username;
     comment.body = body;
     comment.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+
     return comment;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -47,7 +47,6 @@ module.exports = {
     comment.username = username;
     comment.body = body;
     comment.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
-    comments.splice(id, comment);
     return comment;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -37,7 +37,9 @@ module.exports = {
     if (!comment) {
       throw new Error('idと合致するCommentが見つかりません');
     }
-    username;
+    if (!username) {
+      throw new Error('usernameは必須です');
+    }
     body;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -1,4 +1,4 @@
-const daysjs = require('dayjs');
+const dayjs = require('dayjs');
 
 const comments = [];
 
@@ -9,8 +9,8 @@ class Comment {
     this.id = nextId++;
     this.username = username;
     this.body = body;
-    this.createdAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
-    this.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+    this.createdAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+    this.updatedAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
   }
 }
 
@@ -63,7 +63,7 @@ module.exports = {
 
     comment.username = username;
     comment.body = body;
-    comment.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+    comment.updatedAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
 
     return comment;
   },

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -9,8 +9,8 @@ class Comment {
     this.id = nextId++;
     this.username = username;
     this.body = body;
-    this.createdAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss');
-    this.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss');
+    this.createdAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+    this.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
   }
 }
 
@@ -43,5 +43,11 @@ module.exports = {
     if (!body) {
       throw new Error('bodyは必須です');
     }
+
+    comment.username = username;
+    comment.body = body;
+    comment.updatedAt = daysjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+    comments.splice(id, comment);
+    return comment;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -27,4 +27,9 @@ module.exports = {
   findAll: () => {
     return comments;
   },
+  updateComment: ({ id, username, body }) => {
+    id;
+    username;
+    body;
+  },
 };

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -1,5 +1,8 @@
 const assert = require('power-assert');
 const Comment = require('../../models/Comment');
 
-assert;
-Comment;
+describe('Comment.updateCommentのテスト', () => {
+  it('Comment.updateCommentはメソッドである', () => {
+    assert.equal(typeof Comment.updateComment, 'function');
+  });
+});

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -37,4 +37,14 @@ describe('Comment.updateCommentのテスト', () => {
       assert.equal(error.message, 'idと合致するCommentが見つかりません');
     }
   });
+  it('usernameの引数に値が入ってない場合エラーが返される', () => {
+    const data = { id: 1, body: 'test body' };
+
+    try {
+      Comment.updateComment(data);
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'usernameは必須です');
+    }
+  });
 });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -64,7 +64,7 @@ describe('Comment.updateCommentのテスト', () => {
     assert.deepEqual(changedComment, {
       id: data.id,
       username: data.username,
-      body: data.username,
+      body: data.body,
       createdAt: changedComment.createdAt,
       updatedAt: changedComment.updatedAt,
     });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -47,4 +47,14 @@ describe('Comment.updateCommentのテスト', () => {
       assert.equal(error.message, 'usernameは必須です');
     }
   });
+  it('bodyの引数に値が入ってない場合エラーが返される', () => {
+    const data = { id: 1, username: 'test user' };
+
+    try {
+      Comment.updateComment(data);
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'bodyは必須です');
+    }
+  });
 });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -1,0 +1,5 @@
+const assert = require('power-assert');
+const Comment = require('../../models/Comment');
+
+assert;
+Comment;

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -22,7 +22,7 @@ describe('Comment.updateCommentのテスト', () => {
       } catch (error) {
         assert.equal(
           error.message,
-          'id値に適切でない値が入っています、1以上の数字を入れてください'
+          'idに適切でない値が入っています、1以上の数字を入れてください'
         );
       }
     });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -5,4 +5,26 @@ describe('Comment.updateCommentのテスト', () => {
   it('Comment.updateCommentはメソッドである', () => {
     assert.equal(typeof Comment.updateComment, 'function');
   });
+  it('idの引数に不正な値が入っていた場合エラーが返される', () => {
+    const invalidIdList = [
+      { id: 0 },
+      { id: -1 },
+      { id: null },
+      { id: {} },
+      { id: [] },
+      { id: '1' },
+    ];
+
+    invalidIdList.forEach(id => {
+      try {
+        Comment.updateComment(id);
+        assert.fail();
+      } catch (error) {
+        assert.equal(
+          error.message,
+          'id値に適切でない値が入っています、1以上の数字を入れてください'
+        );
+      }
+    });
+  });
 });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -27,4 +27,14 @@ describe('Comment.updateCommentのテスト', () => {
       }
     });
   });
+  it('idのプロパティ値と合致するCommentがない場合エラーが返される', () => {
+    const invalidId = { id: 9999999999 };
+
+    try {
+      Comment.updateComment(invalidId);
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'idと合致するCommentが見つかりません');
+    }
+  });
 });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -57,4 +57,20 @@ describe('Comment.updateCommentのテスト', () => {
       assert.equal(error.message, 'bodyは必須です');
     }
   });
+  it('適切なデータを渡した際、指定したidと合致するcommentのusernameとbodyが変更され、返される', () => {
+    const data = { id: 1, username: 'update user', body: 'update body' };
+
+    const changedComment = Comment.updateComment(data);
+    assert.deepEqual(changedComment, {
+      id: data.id,
+      username: data.username,
+      body: data.username,
+      createdAt: changedComment.createdAt,
+      updatedAt: changedComment.updatedAt,
+    });
+    assert.equal(changedComment.updatedAt > changedComment.createdAt, true); // 変更された日時の方と作成された日時が違うかのテスト
+
+    const currentComments = Comment.findAll();
+    assert.deepEqual(currentComments[0], changedComment); // 変更したコメントと同じID値の配列に組み込まれているコメントは同じかテスト
+  });
 });


### PR DESCRIPTION
# updateCommentの作成

メソッドの機能として、README.mdに記載されている

>「POST /api/comments」「PUT /api/comments/:id」を実行する際は、username、 bodyの送信を必須とする。

それと追加で

- id値に適切でないプロパティ値が入っている
- id値と合致するcommentが見つからない

これらの場合もmodel側でエラーを出し、id、username、body共に適切な値が入っている場合のみメソッドが成功するようにコーディングしました

# updateCommentのテスト

## テスト内容

1. `updateComment`はメソッドである
2. `id`の引数に適切でないプロパティ値が入っていた場合、エラーが返される
3. `id`の値と合致する`comment`が見つからない場合、エラーが返される
4. `username`の引数に値が入ってない場合エラーが返される
5. `body`の引数に値が入ってない場合エラーが返される
6. 適切なデータが渡された場合、指定した`id`と合致する`comment`の`username`と`body`が変更され、そのデータが返される
7. `6.`と同時に更新された`comment`の`updatedAt`は`createdAt`と時間が違う
8. `6.`と同時に更新された`comment`と、同じID値の配列に組み込まれている`comment`は同じである