### PR TITLE
`「POST/api/comments」`リクエストを投げると、`新規にComment1件を作成し、作成されたComment`がレスポンス値として返ってくる機能、およびそのテストの実装

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,8 @@ const router = require('./routers/comments');
 
 const app = express();
 
-app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use('/api/comments', router);
 

--- a/app.js
+++ b/app.js
@@ -1,7 +1,11 @@
 const express = require('express');
+const bodyParser = require('body-parser');
 const router = require('./routers/comments');
 
 const app = express();
+
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
 
 app.use('/api/comments', router);
 

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -6,8 +6,14 @@ module.exports = {
 
     res.status(200).json(storedComments);
   },
-  putComment: (req, res) => {
-    req;
-    res;
+  postComment: (req, res) => {
+    try {
+      const { username, body } = req.body;
+      const createdComment = Comment.createComment({ username, body });
+
+      res.status(200).json(createdComment);
+    } catch (error) {
+      res.status(400).json({ message: error.message });
+    }
   },
 };

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -6,4 +6,8 @@ module.exports = {
 
     res.status(200).json(storedComments);
   },
+  putComment: (req, res) => {
+    req;
+    res;
+  },
 };

--- a/helper/requestHelper.js
+++ b/helper/requestHelper.js
@@ -1,11 +1,12 @@
-const request = require('supertest');
-request;
+const requestHelper = require('supertest');
+
 const app = require('../app');
-app;
+
 module.exports = {
   request: ({ method, endPoint, statusCode }) => {
-    method;
-    endPoint;
-    statusCode;
+    return requestHelper(app)
+      [method](endPoint)
+      .expect('Content-Type', /json/)
+      .expect(statusCode);
   },
 };

--- a/helper/requestHelper.js
+++ b/helper/requestHelper.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+request;
+const app = require('../app');
+app;
+module.exports = {
+  request: ({ method, endPoint, statusCode }) => {
+    method;
+    endPoint;
+    statusCode;
+  },
+};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const app = require('./app');
 
-const PORT = 8080;
+const PORT = 8050;
 
 app.listen(PORT, function() {
   console.log(`Example app listening on port ${PORT}`);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "singleQuote": true
   },
   "dependencies": {
+    "body-parser": "^1.18.3",
     "dayjs": "^1.8.12",
     "express": "^4.16.4"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "nodemon index.js",
     "test": "mocha",
-    "lint": "eslint --fix controllers models routers test",
+    "lint": "eslint --fix controllers models routers test helper",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/routers/comments.js
+++ b/routers/comments.js
@@ -5,6 +5,6 @@ const controller = require('../controllers/comments');
 router
   .route('/')
   .get(controller.getComments)
-  .put(controller.putComment);
+  .post(controller.postComment);
 
 module.exports = router;

--- a/routers/comments.js
+++ b/routers/comments.js
@@ -2,6 +2,9 @@ const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/comments');
 
-router.route('/').get(controller.getComments);
+router
+  .route('/')
+  .get(controller.getComments)
+  .put(controller.putComment);
 
 module.exports = router;

--- a/test/app/api/getComment.test.js
+++ b/test/app/api/getComment.test.js
@@ -1,14 +1,13 @@
-const request = require('supertest');
+const requestHelper = require('../../../helper/requestHelper');
 const assert = require('power-assert');
-
-const app = require('../../../app');
 
 describe('test 「GET /api/comments」', () => {
   it('GETリクエストで返されたデータは適切である', async () => {
-    const response = await request(app)
-      .get('/api/comments')
-      .expect('Content-Type', /json/)
-      .expect(200);
+    const response = await requestHelper.request({
+      method: 'get',
+      endPoint: '/api/comments',
+      statusCode: 200,
+    });
 
     const comments = response.body;
     assert.equal(Array.isArray(comments), true);

--- a/test/app/api/postComment.test.js
+++ b/test/app/api/postComment.test.js
@@ -1,0 +1,8 @@
+const request = require('supertest');
+const assert = require('power-assert');
+
+const app = require('../../../app');
+
+app;
+request;
+assert;

--- a/test/app/api/postComment.test.js
+++ b/test/app/api/postComment.test.js
@@ -1,8 +1,18 @@
-const request = require('supertest');
+const requestHelper = require('../../../helper/requestHelper');
 const assert = require('power-assert');
 
-const app = require('../../../app');
+describe('test 「POST /api/comments」', () => {
+  it('usernameを送らなかった場合400エラーが返る', async () => {
+    const data = { body: 'test body' };
 
-app;
-request;
-assert;
+    const response = await requestHelper
+      .request({
+        method: 'post',
+        endPoint: '/api/comments',
+        statusCode: 400,
+      })
+      .send(data);
+
+    assert.deepEqual(response.body, { message: 'usernameは必須です' });
+  });
+});

--- a/test/app/api/postComment.test.js
+++ b/test/app/api/postComment.test.js
@@ -28,4 +28,24 @@ describe('test 「POST /api/comments」', () => {
 
     assert.deepEqual(response.body, { message: 'bodyは必須です' });
   });
+  it('適切なデータを送った場合、新規作成されたコメントが一件返ってくる', async () => {
+    const data = { username: 'user', body: 'body' };
+
+    const response = await requestHelper
+      .request({
+        method: 'post',
+        endPoint: '/api/comments',
+        statusCode: 200,
+      })
+      .send(data);
+
+    const comment = response.body;
+    assert.deepEqual(comment, {
+      id: comment.id,
+      username: data.username,
+      body: data.body,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+    });
+  });
 });

--- a/test/app/api/postComment.test.js
+++ b/test/app/api/postComment.test.js
@@ -15,4 +15,17 @@ describe('test 「POST /api/comments」', () => {
 
     assert.deepEqual(response.body, { message: 'usernameは必須です' });
   });
+  it('bodyを送らなかった場合400エラーが返る', async () => {
+    const data = { username: 'test user' };
+
+    const response = await requestHelper
+      .request({
+        method: 'post',
+        endPoint: '/api/comments',
+        statusCode: 400,
+      })
+      .send(data);
+
+    assert.deepEqual(response.body, { message: 'bodyは必須です' });
+  });
 });

--- a/test/app/api/postComment.test.js
+++ b/test/app/api/postComment.test.js
@@ -1,6 +1,16 @@
 const requestHelper = require('../../../helper/requestHelper');
 const assert = require('power-assert');
 
+const getComments = async () => {
+  const response = await requestHelper.request({
+    method: 'get',
+    endPoint: '/api/comments',
+    statusCode: 200,
+  });
+
+  return response.body;
+};
+
 describe('test 「POST /api/comments」', () => {
   it('usernameを送らなかった場合400エラーが返る', async () => {
     const data = { body: 'test body' };
@@ -28,7 +38,9 @@ describe('test 「POST /api/comments」', () => {
 
     assert.deepEqual(response.body, { message: 'bodyは必須です' });
   });
-  it('適切なデータを送った場合、新規作成されたコメントが一件返ってくる', async () => {
+  it('適切なデータを送った場合、新規作成されたコメントが一件返ってくる、また配列内には新規作成されたコメントが一件格納されている', async () => {
+    const oldComments = await getComments();
+
     const data = { username: 'user', body: 'body' };
 
     const response = await requestHelper
@@ -47,5 +59,9 @@ describe('test 「POST /api/comments」', () => {
       createdAt: comment.createdAt,
       updatedAt: comment.updatedAt,
     });
+
+    const currentComments = await getComments();
+
+    assert.equal(oldComments.length + 1, currentComments.length);
   });
 });


### PR DESCRIPTION
## 必要なライブラリ

- body-parser
クライアントからPOST送信されたデータをサーバ側で受け取り、処理するためのライブラリ。 `req.body`経由でPOSTデータを受け取ることができます

# postCommentの()作成

メソッドの機能として、README.mdに記載されている

>  「POST /api/comments」「PUT /api/comments/:id」を実行する際は、username、 bodyの送信を必須とする。
username が送信データに含まれていない場合は、usernameは必須です というエラーメッセージを返し、ステータスコードには400を返す
body が送信データに含まれていない場合は、bodyは必須です というエラーメッセージを返す、ステータスコードには400を返す

決まりに乗っ取り、`try/catch`文で成功、失敗した際の挙動を分けました

## postCommentのテスト

#### テスト内容

1. `title`を送らなかった場合400エラーが返る
2. `body`を送らなかった場合400エラーが返る
3. 適切なデータを送った場合、新規作成されたコメントが一件返される
4. `3.`と同時に、新規作成されたコメント1件が`comments`配列に格納されている

## supertest用のhelperファイル作成

**DRY**の考えに基づき、supertestで記述するコードをモジュール化しました