### PR TITLE
「「PUT/api/comments/:id」リクエストを投げると、id値に紐づいたComment1件を更新して、更新したComment1件がレスポンス値として返ってくる」機能、およびそのテストの実装

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -16,7 +16,7 @@ module.exports = {
       res.status(400).json({ message: error.message });
     }
   },
-  updateComment: (req, res) => {
+  putComment: (req, res) => {
     res;
     req;
   },

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -17,7 +17,19 @@ module.exports = {
     }
   },
   putComment: (req, res) => {
-    res;
-    req;
+    try {
+      const parseId = parseInt(req.params.id, 10);
+      const { username, body } = req.body;
+
+      const updatedComment = Comment.updateComment({
+        id: parseId,
+        username,
+        body,
+      });
+
+      res.status(200).json(updatedComment);
+    } catch (error) {
+      res.status(400).json({ message: error.message });
+    }
   },
 };

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -16,4 +16,8 @@ module.exports = {
       res.status(400).json({ message: error.message });
     }
   },
+  updateComment: (req, res) => {
+    res;
+    req;
+  },
 };

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -18,11 +18,11 @@ module.exports = {
   },
   putComment: (req, res) => {
     try {
-      const parseId = parseInt(req.params.id, 10);
+      const parsedId = parseInt(req.params.id, 10);
       const { username, body } = req.body;
 
       const updatedComment = Comment.updateComment({
-        id: parseId,
+        id: parsedId,
         username,
         body,
       });

--- a/routers/comments.js
+++ b/routers/comments.js
@@ -7,4 +7,6 @@ router
   .get(controller.getComments)
   .post(controller.postComment);
 
+router.route('/:id').put(controller.putComment);
+
 module.exports = router;

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -69,7 +69,7 @@ describe('TEST 「PUT api/comments/:id」', () => {
     });
   });
   it('適切なデータを送った場合、idと紐つくコメント一件のusernameとbodyが変更され返ってくる、なお配列内にあったidと紐つくコメントは変更されたコメントに上書きされる', async () => {
-    const oldComment = await getComments();
+    const oldComments = await getComments();
 
     const data = {
       username: 'test updating user',
@@ -87,6 +87,6 @@ describe('TEST 「PUT api/comments/:id」', () => {
       updatedAt: comment.updatedAt,
     });
 
-    assert.equal(oldComment[0] === comment, false);
+    assert.notDeepStrictEqual(oldComments[0], comment);
   });
 });

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -7,7 +7,7 @@ const getComments = async () => {
     endPoint: '/api/comments',
     statusCode: 200,
   });
-  return response;
+  return response.body;
 };
 
 const putComment = async (code, id, data) => {

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -1,0 +1,5 @@
+const requestHelper = require('../../../helper/requestHelper');
+const assert = require('power-assert');
+
+requestHelper;
+assert;

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -22,13 +22,22 @@ const putComment = async (code, data) => {
 };
 
 describe('TEST 「PUT api/comments/:id」', () => {
-  it('適切で無いidを送ると400エラーが返る', async () => {
-    const data = { id: '1' };
+  it('適切でないidを送ると400エラーが返る', async () => {
+    const data = { id: null };
 
     const response = await putComment(400, data);
 
     assert.deepEqual(response.body, {
       message: 'idに適切でない値が入っています、1以上の数字を入れてください',
+    });
+  });
+  it('送られたidと紐つくコメントがないと400エラーが返る', async () => {
+    const data = { id: 999999999999 };
+
+    const response = await putComment(400, data);
+
+    assert.deepEqual(response.body, {
+      message: 'idと合致するCommentが見つかりません',
     });
   });
 });

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -1,5 +1,28 @@
 const requestHelper = require('../../../helper/requestHelper');
 const assert = require('power-assert');
 
+const getComments = async () => {
+  const response = await requestHelper.request({
+    method: 'get',
+    endPoint: '/api/comments',
+    statusCode: 200,
+  });
+  return response;
+};
+
+const putComment = async (code, data) => {
+  const response = await requestHelper
+    .request({
+      method: 'put',
+      endPoint: '/api/comments/:id',
+      statusCode: code,
+    })
+    .send(data);
+  return response;
+};
+
+describe('TEST 「PUT api/comments/:id」', () => {});
 requestHelper;
 assert;
+getComments();
+putComment();

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -60,6 +60,38 @@ describe('TEST 「PUT api/comments/:id」', () => {
       message: 'usernameは必須です',
     });
   });
+  it('bodyを送らなかった場合400エラーが返る', async () => {
+    const data = {
+      id: 2,
+      username: 'test user',
+    };
+
+    const response = await putComment(400, data);
+
+    assert.deepEqual(response.body, {
+      message: 'bodyは必須です',
+    });
+  });
+  it('適切なデータを送った場合、idと紐つくコメント一件のusernameとbodyが変更され返ってくる、なお配列内にあったidと紐つくコメンは変更されたコメントに上書きされる', async () => {
+    const oldComment = await getComments();
+
+    const data = {
+      id: 2,
+      username: 'test updating user',
+      body: 'test updating body',
+    };
+
+    const response = await putComment(200, data);
+
+    const comment = response.body;
+    assert.deepEqual(comment, {
+      id: data.id,
+      username: data.username,
+      body: data.body,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+    });
+
+    assert.equal(oldComment[1] === comment, false);
+  });
 });
-assert;
-getComments();

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -48,7 +48,6 @@ describe('TEST 「PUT api/comments/:id」', () => {
   });
   it('usernameを送らなかった場合400エラーが返る', async () => {
     const data = {
-      id: 2,
       body: 'test body',
     };
 
@@ -69,7 +68,7 @@ describe('TEST 「PUT api/comments/:id」', () => {
       message: 'bodyは必須です',
     });
   });
-  it('適切なデータを送った場合、idと紐つくコメント一件のusernameとbodyが変更され返ってくる、なお配列内にあったidと紐つくコメンは変更されたコメントに上書きされる', async () => {
+  it('適切なデータを送った場合、idと紐つくコメント一件のusernameとbodyが変更され返ってくる、なお配列内にあったidと紐つくコメントは変更されたコメントに上書きされる', async () => {
     const oldComment = await getComments();
 
     const data = {

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -21,8 +21,16 @@ const putComment = async (code, data) => {
   return response;
 };
 
-describe('TEST 「PUT api/comments/:id」', () => {});
-requestHelper;
+describe('TEST 「PUT api/comments/:id」', () => {
+  it('適切で無いidを送ると400エラーが返る', async () => {
+    const data = { id: '1' };
+
+    const response = await putComment(400, data);
+
+    assert.deepEqual(response.body, {
+      message: 'idに適切でない値が入っています、1以上の数字を入れてください',
+    });
+  });
+});
 assert;
 getComments();
-putComment();

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -10,11 +10,11 @@ const getComments = async () => {
   return response;
 };
 
-const putComment = async (code, data) => {
+const putComment = async (code, id, data) => {
   const response = await requestHelper
     .request({
       method: 'put',
-      endPoint: '/api/comments/:id',
+      endPoint: `/api/comments/${id}`,
       statusCode: code,
     })
     .send(data);
@@ -24,12 +24,11 @@ const putComment = async (code, data) => {
 describe('TEST 「PUT api/comments/:id」', () => {
   it('適切でないidを送ると400エラーが返る', async () => {
     const data = {
-      id: null,
       username: 'test user',
       body: 'test body',
     };
 
-    const response = await putComment(400, data);
+    const response = await putComment(400, 0, data);
 
     assert.deepEqual(response.body, {
       message: 'idに適切でない値が入っています、1以上の数字を入れてください',
@@ -37,12 +36,11 @@ describe('TEST 「PUT api/comments/:id」', () => {
   });
   it('送られたidと紐つくコメントがないと400エラーが返る', async () => {
     const data = {
-      id: 999999999999,
       username: 'test user',
       body: 'test body',
     };
 
-    const response = await putComment(400, data);
+    const response = await putComment(400, 9999999, data);
 
     assert.deepEqual(response.body, {
       message: 'idと合致するCommentが見つかりません',
@@ -54,7 +52,7 @@ describe('TEST 「PUT api/comments/:id」', () => {
       body: 'test body',
     };
 
-    const response = await putComment(400, data);
+    const response = await putComment(400, 1, data);
 
     assert.deepEqual(response.body, {
       message: 'usernameは必須です',
@@ -62,11 +60,10 @@ describe('TEST 「PUT api/comments/:id」', () => {
   });
   it('bodyを送らなかった場合400エラーが返る', async () => {
     const data = {
-      id: 2,
       username: 'test user',
     };
 
-    const response = await putComment(400, data);
+    const response = await putComment(400, 1, data);
 
     assert.deepEqual(response.body, {
       message: 'bodyは必須です',
@@ -76,22 +73,21 @@ describe('TEST 「PUT api/comments/:id」', () => {
     const oldComment = await getComments();
 
     const data = {
-      id: 2,
       username: 'test updating user',
       body: 'test updating body',
     };
 
-    const response = await putComment(200, data);
+    const response = await putComment(200, 1, data);
 
     const comment = response.body;
     assert.deepEqual(comment, {
-      id: data.id,
+      id: 1,
       username: data.username,
       body: data.body,
       createdAt: comment.createdAt,
       updatedAt: comment.updatedAt,
     });
 
-    assert.equal(oldComment[1] === comment, false);
+    assert.equal(oldComment[0] === comment, false);
   });
 });

--- a/test/app/api/putComment.test.js
+++ b/test/app/api/putComment.test.js
@@ -23,7 +23,11 @@ const putComment = async (code, data) => {
 
 describe('TEST 「PUT api/comments/:id」', () => {
   it('適切でないidを送ると400エラーが返る', async () => {
-    const data = { id: null };
+    const data = {
+      id: null,
+      username: 'test user',
+      body: 'test body',
+    };
 
     const response = await putComment(400, data);
 
@@ -32,12 +36,28 @@ describe('TEST 「PUT api/comments/:id」', () => {
     });
   });
   it('送られたidと紐つくコメントがないと400エラーが返る', async () => {
-    const data = { id: 999999999999 };
+    const data = {
+      id: 999999999999,
+      username: 'test user',
+      body: 'test body',
+    };
 
     const response = await putComment(400, data);
 
     assert.deepEqual(response.body, {
       message: 'idと合致するCommentが見つかりません',
+    });
+  });
+  it('usernameを送らなかった場合400エラーが返る', async () => {
+    const data = {
+      id: 2,
+      body: 'test body',
+    };
+
+    const response = await putComment(400, data);
+
+    assert.deepEqual(response.body, {
+      message: 'usernameは必須です',
     });
   });
 });


### PR DESCRIPTION
# putCommentの作成

今回は、アドレスの末端「:id」の部分に数字を入力し、そこから紐づくcommentを検索するので、入力したアドレスを値として受け取る必要がありますので、`ルートパラメータ`を使用します

[Express 4.x - API リファレンス:ルート・パラメータ](https://expressjs.com/ja/guide/routing.html#route-parameters)
> ルート・パラメータは、URL内の指定された値を取得するために使用されるURLセグメントのことを言います。捕捉された値はreq.paramsオブジェクトの中で、パスに指定されたルート・パラメータの名前をそれぞれのキーとして設定されます。

ルートパラメータで得たい部分は「`:{任意の名前}`」と書く必要があります。

ルートパラメータで得た値は`req.params`オブジェクトでプロパティ値として使用することができます。

しかし、`req.params`で受け取った値は **文字列(string)** となっているので、`parseInt`で **数値(number)** に変換しました。

`username`、`body`は`req.body`で受け取るようにしています。

# putCommentのテスト

APIの挙動テストは共通化できそうだったので関数を作成、ステータスコード、id値、入力データを引数に設定

## テスト内容

1. 適切でない`id`を送ると400エラーが返る
2. 送られた`id`と紐つくコメントがないと400エラーが返る
3. `username`を送らなかった場合400エラーが返る
4. `body`を送らなかった場合400エラーが返る
5. 適切なデータを送った場合、`id`と紐つくコメント一件の`username`と`body`が変更され返ってくる
6. `5.`と同時に、配列内にあった`id`と紐つくコメントは変更されたコメントに上書きされる
