### PR TITLE
指定したid値と合致するコメント一件を配列から削除して、削除したコメント一件を返すメソッド、およびそのメソッドの作成

### DIFF
--- a/models/Comment.js
+++ b/models/Comment.js
@@ -73,5 +73,10 @@ module.exports = {
         'idに適切でない値が入っています、1以上の数字を入れてください'
       );
     }
+
+    const comment = comments.find(comment => id === comment.id);
+    if (!comment) {
+      throw new Error('idと合致するCommentが見つかりません');
+    }
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -68,6 +68,10 @@ module.exports = {
     return comment;
   },
   deleteComment: ({ id }) => {
-    id;
+    if (typeof id !== 'number' || id < 1) {
+      throw new Error(
+        'idに適切でない値が入っています、1以上の数字を入れてください'
+      );
+    }
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -67,4 +67,7 @@ module.exports = {
 
     return comment;
   },
+  deleteComment: ({ id }) => {
+    id;
+  },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -74,10 +74,12 @@ module.exports = {
       );
     }
 
-    const comment = comments.find(comment => id === comment.id);
-    if (!comment) {
+    const target = comments.findIndex(comment => id === comment.id);
+    if (target === -1) {
       throw new Error('idと合致するCommentが見つかりません');
     }
-    return comment;
+    const deletedComment = comments.splice(target, 1)[0];
+
+    return deletedComment;
   },
 };

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -78,5 +78,6 @@ module.exports = {
     if (!comment) {
       throw new Error('idと合致するCommentが見つかりません');
     }
+    return comment;
   },
 };

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -21,7 +21,7 @@ describe('Comment.deleteCommentのテスト', () => {
         assert.fail();
       } catch (error) {
         assert.strictEqual(
-          error.message,
+          error.body,
           'idに適切でない値が入っています、1以上の数字を入れてください'
         );
       }

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -37,26 +37,26 @@ describe('Comment.deleteCommentのテスト', () => {
       assert.strictEqual(error.message, 'idと合致するCommentが見つかりません');
     }
   });
-  it('適切なid値を送った場合、idと合致するComment一件が返される', () => {});
-  const validId = { id: 1 };
+  it('適切なid値を送った場合、idと合致するComment一件が返される', () => {
+    const validId = { id: 1 };
 
-  const deletedComment = Comment.deleteComment(validId);
-  assert.deepEqual(deletedComment, {
-    id: validId.id,
-    username: deletedComment.username,
-    body: deletedComment.body,
-    createdAt: deletedComment.createdAt,
-    updatedAt: deletedComment.updatedAt,
+    const deletedComment = Comment.deleteComment(validId);
+    assert.deepEqual(deletedComment, {
+      id: validId.id,
+      username: deletedComment.username,
+      body: deletedComment.body,
+      createdAt: deletedComment.createdAt,
+      updatedAt: deletedComment.updatedAt,
+    });
   });
   it('適切なid値を送った場合、idと合致するComment一件が配列から削除される', () => {
     const oldComments = Comment.findAll();
+    const validId = { id: 2 };
 
-    const validId = { id: 1 };
-
-    Comment.deletedComment(validId);
+    Comment.deleteComment(validId);
 
     const currentComments = Comment.findAll();
 
-    assert.equal(oldComments.length + 1, currentComments.length);
+    assert.equal(oldComments.length, currentComments.length + 1);
   });
 });

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -37,6 +37,15 @@ describe('Comment.deleteCommentのテスト', () => {
       assert.strictEqual(error.message, 'idと合致するCommentが見つかりません');
     }
   });
+  it('適切なid値を送った場合、idと合致するComment一件が削除され、返される', () => {});
+  const validId = { id: 1 };
+
+  const comment = Comment.deleteComment(validId);
+  assert.deepStrictEqual(comment, {
+    id: validId.id,
+    username: comment.username,
+    body: comment.body,
+    createdAt: comment.createdAt,
+    updatadAt: comment.updatadAt,
+  });
 });
-assert;
-Comment;

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -37,7 +37,7 @@ describe('Comment.deleteCommentのテスト', () => {
       assert.strictEqual(error.message, 'idと合致するCommentが見つかりません');
     }
   });
-  it('適切なid値を送った場合、idと合致するComment一件が削除され、返される', () => {});
+  it('適切なid値を送った場合、idと合致するComment一件が返される', () => {});
   const validId = { id: 1 };
 
   const deletedComment = Comment.deleteComment(validId);
@@ -47,5 +47,16 @@ describe('Comment.deleteCommentのテスト', () => {
     body: deletedComment.body,
     createdAt: deletedComment.createdAt,
     updatedAt: deletedComment.updatedAt,
+  });
+  it('適切なid値を送った場合、idと合致するComment一件が配列から削除される', () => {
+    const oldComments = Comment.findAll();
+
+    const validId = { id: 1 };
+
+    Comment.deletedComment(validId);
+
+    const currentComments = Comment.findAll();
+
+    assert.equal(oldComments.length + 1, currentComments.length);
   });
 });

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -1,5 +1,10 @@
 const assert = require('power-assert');
 const Comment = require('../../models/Comment');
 
+describe('Comment.deleteCommentのテスト', () => {
+  it('Comment.deleteCommentはメソッドである', () => {
+    assert.strictEqual(typeof Comment.deleteComment, 'function');
+  });
+});
 assert;
 Comment;

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -21,11 +21,21 @@ describe('Comment.deleteCommentのテスト', () => {
         assert.fail();
       } catch (error) {
         assert.strictEqual(
-          error.body,
+          error.message,
           'idに適切でない値が入っています、1以上の数字を入れてください'
         );
       }
     });
+  });
+  it('idのプロパティ値と合致するCommentがない場合、エラーが返る', () => {
+    const invalidId = { id: 999999999 };
+
+    try {
+      Comment.deleteComment(invalidId);
+      assert.fail();
+    } catch (error) {
+      assert.strictEqual(error.message, 'idと合致するCommentが見つかりません');
+    }
   });
 });
 assert;

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -1,0 +1,5 @@
+const assert = require('power-assert');
+const Comment = require('../../models/Comment');
+
+assert;
+Comment;

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -5,6 +5,28 @@ describe('Comment.deleteCommentのテスト', () => {
   it('Comment.deleteCommentはメソッドである', () => {
     assert.strictEqual(typeof Comment.deleteComment, 'function');
   });
+  it('idの引数に不正な値が入っていた場合、エラーが返る', () => {
+    const invalidIdList = [
+      { id: 0 },
+      { id: -1 },
+      { id: null },
+      { id: {} },
+      { id: [] },
+      { id: '1' },
+    ];
+
+    invalidIdList.forEach(id => {
+      try {
+        Comment.deleteComment(id);
+        assert.fail();
+      } catch (error) {
+        assert.strictEqual(
+          error.message,
+          'idに適切でない値が入っています、1以上の数字を入れてください'
+        );
+      }
+    });
+  });
 });
 assert;
 Comment;

--- a/test/models/deleteComment.test.js
+++ b/test/models/deleteComment.test.js
@@ -40,12 +40,12 @@ describe('Comment.deleteCommentのテスト', () => {
   it('適切なid値を送った場合、idと合致するComment一件が削除され、返される', () => {});
   const validId = { id: 1 };
 
-  const comment = Comment.deleteComment(validId);
-  assert.deepStrictEqual(comment, {
+  const deletedComment = Comment.deleteComment(validId);
+  assert.deepEqual(deletedComment, {
     id: validId.id,
-    username: comment.username,
-    body: comment.body,
-    createdAt: comment.createdAt,
-    updatadAt: comment.updatadAt,
+    username: deletedComment.username,
+    body: deletedComment.body,
+    createdAt: deletedComment.createdAt,
+    updatedAt: deletedComment.updatedAt,
   });
 });

--- a/test/models/updateComment.test.js
+++ b/test/models/updateComment.test.js
@@ -38,7 +38,7 @@ describe('Comment.updateCommentのテスト', () => {
     }
   });
   it('usernameの引数に値が入ってない場合エラーが返される', () => {
-    const data = { id: 1, body: 'test body' };
+    const data = { id: 3, body: 'test body' };
 
     try {
       Comment.updateComment(data);
@@ -48,7 +48,7 @@ describe('Comment.updateCommentのテスト', () => {
     }
   });
   it('bodyの引数に値が入ってない場合エラーが返される', () => {
-    const data = { id: 1, username: 'test user' };
+    const data = { id: 3, username: 'test user' };
 
     try {
       Comment.updateComment(data);
@@ -58,7 +58,7 @@ describe('Comment.updateCommentのテスト', () => {
     }
   });
   it('適切なデータを渡した際、指定したidと合致するcommentのusernameとbodyが変更され、返される', () => {
-    const data = { id: 1, username: 'update user', body: 'update body' };
+    const data = { id: 3, username: 'update user', body: 'update body' };
 
     const changedComment = Comment.updateComment(data);
     assert.deepEqual(changedComment, {


### PR DESCRIPTION
# deleteCommentの作成
メソッドの機能として
- id値に適切なプロパティ値が入ってない
- id値と合致する`comment`がない
場合にエラーを送るようにしました。

## Array.prototype.findIndex()
> findIndex() メソッドは、配列内の要素が指定されたテスト関数を満たす場合、配列内の インデックス を返します。そうでない場合は -1 を返します。

id値とインデックス値は違うので、`findIndex`を使用して、id値と合致するコメントのインデックス値を会得、`splice`の第一引数に渡してコメント1件を削除するようにしました。

# deleteCommentのテスト
1. `deleteComment`はメソッドである
2. `id`の引数に不正な値が入っていた場合エラーが返される
3. `id`のプロパティ値と合致する`Comment`がない場合エラーが返る
4. 適切な値を送った場合、`id`と合致する`comment`一件が返される
5. 適切な値を送った場合、`id`と合致する`comment`一件が配列から削除される

### 修正

`deleteComment.test.js`のテストを実行すると、`updateComment.test.js`にも影響が出たので微修正