### PR TITLE
「DELETE/api/comment/:id」リクエストを投げると、id値に紐づいたComment1件を削除して、削除したComment1件がレスポンス値として返ってくる

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -33,7 +33,16 @@ module.exports = {
     }
   },
   deleteComment: (req, res) => {
-    req;
-    res;
+    try {
+      const parsedId = parseInt(req.params.id, 10);
+
+      const removeComment = Comment.removeComment({
+        id: parsedId,
+      });
+
+      res.status(200).json(removeComment);
+    } catch (error) {
+      res.status(400).json({ message: error.message });
+    }
   },
 };

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -32,4 +32,8 @@ module.exports = {
       res.status(400).json({ message: error.message });
     }
   },
+  deleteComment: (req, res) => {
+    req;
+    res;
+  },
 };

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -36,11 +36,11 @@ module.exports = {
     try {
       const parsedId = parseInt(req.params.id, 10);
 
-      const removeComment = Comment.removeComment({
+      const removedComment = Comment.removeComment({
         id: parsedId,
       });
 
-      res.status(200).json(removeComment);
+      res.status(200).json(removedComment);
     } catch (error) {
       res.status(400).json({ message: error.message });
     }

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -67,7 +67,7 @@ module.exports = {
 
     return comment;
   },
-  deleteComment: ({ id }) => {
+  removeComment: ({ id }) => {
     if (typeof id !== 'number' || id < 1) {
       throw new Error(
         'idに適切でない値が入っています、1以上の数字を入れてください'

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -15,7 +15,7 @@ class Comment {
 }
 
 // テスト、確認用に配列に挿入するDBの作成
-for (let i = 0; i < 3; i++) {
+for (let i = 0; i < 5; i++) {
   const comment = new Comment({
     username: 'username' + i,
     body: 'body' + i,

--- a/routers/comments.js
+++ b/routers/comments.js
@@ -7,6 +7,9 @@ router
   .get(controller.getComments)
   .post(controller.postComment);
 
-router.route('/:id').put(controller.putComment);
+router
+  .route('/:id')
+  .put(controller.putComment)
+  .delete(controller.deleteComment);
 
 module.exports = router;

--- a/test/app/api/deleteComment.test.js
+++ b/test/app/api/deleteComment.test.js
@@ -10,8 +10,6 @@ const getComments = async () => {
   return response.body;
 };
 
-getComments;
-
 const deleteComment = async (id, code) => {
   const response = await requestHelper.request({
     method: 'delete',
@@ -35,5 +33,24 @@ describe('TEST 「DELETE api/comments/:id」', () => {
     assert.deepStrictEqual(response.body, {
       message: 'idと合致するCommentが見つかりません',
     });
+  });
+  it('適切なid値を送ると、idと合致するCommentが返ってくる、また該当のCommentは配列内から削除される', async () => {
+    const oldComments = await getComments();
+
+    const validId = 4;
+    const response = await deleteComment(validId, 200);
+    const comment = response.body;
+
+    assert.deepStrictEqual(comment, {
+      id: validId,
+      username: comment.username,
+      body: comment.body,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+    });
+
+    const currentComments = await getComments();
+
+    assert.strictEqual(oldComments.length, currentComments.length + 1);
   });
 });

--- a/test/app/api/deleteComment.test.js
+++ b/test/app/api/deleteComment.test.js
@@ -1,0 +1,24 @@
+const assert = require('power-assert');
+const requestHelper = require('../../../helper/requestHelper');
+
+const getComments = async () => {
+  const response = await requestHelper.request({
+    method: 'get',
+    endPoint: '/api/comments',
+    statusCode: 200,
+  });
+  return response.body;
+};
+
+const deleteComment = async (id, code) => {
+  const response = await requestHelper.request({
+    method: 'delete',
+    endPoint: `/api/comments/${id}`,
+    statusCode: code,
+  });
+  return response;
+};
+
+assert;
+getComments;
+deleteComment;

--- a/test/app/api/deleteComment.test.js
+++ b/test/app/api/deleteComment.test.js
@@ -10,6 +10,8 @@ const getComments = async () => {
   return response.body;
 };
 
+getComments;
+
 const deleteComment = async (id, code) => {
   const response = await requestHelper.request({
     method: 'delete',
@@ -19,6 +21,12 @@ const deleteComment = async (id, code) => {
   return response;
 };
 
-assert;
-getComments;
-deleteComment;
+describe('TEST 「DELETE api/comments/:id」', () => {
+  it('適切でないid値を送るとエラーが返る', async () => {
+    const response = await deleteComment(0, 400);
+
+    assert.deepStrictEqual(response.body, {
+      message: 'idに適切でない値が入っています、1以上の数字を入れてください',
+    });
+  });
+});

--- a/test/app/api/deleteComment.test.js
+++ b/test/app/api/deleteComment.test.js
@@ -29,4 +29,11 @@ describe('TEST 「DELETE api/comments/:id」', () => {
       message: 'idに適切でない値が入っています、1以上の数字を入れてください',
     });
   });
+  it('idの値と合致するCommentがない場合エラーが返る', async () => {
+    const response = await deleteComment(9999999, 400);
+
+    assert.deepStrictEqual(response.body, {
+      message: 'idと合致するCommentが見つかりません',
+    });
+  });
 });

--- a/test/models/removeComment.test.js
+++ b/test/models/removeComment.test.js
@@ -1,9 +1,9 @@
 const assert = require('power-assert');
 const Comment = require('../../models/Comment');
 
-describe('Comment.deleteCommentのテスト', () => {
-  it('Comment.deleteCommentはメソッドである', () => {
-    assert.strictEqual(typeof Comment.deleteComment, 'function');
+describe('Comment.removeComment', () => {
+  it('Comment.removeCommentはメソッドである', () => {
+    assert.strictEqual(typeof Comment.removeComment, 'function');
   });
   it('idの引数に不正な値が入っていた場合、エラーが返る', () => {
     const invalidIdList = [
@@ -17,7 +17,7 @@ describe('Comment.deleteCommentのテスト', () => {
 
     invalidIdList.forEach(id => {
       try {
-        Comment.deleteComment(id);
+        Comment.removeComment(id);
         assert.fail();
       } catch (error) {
         assert.strictEqual(
@@ -31,7 +31,7 @@ describe('Comment.deleteCommentのテスト', () => {
     const invalidId = { id: 999999999 };
 
     try {
-      Comment.deleteComment(invalidId);
+      Comment.removeComment(invalidId);
       assert.fail();
     } catch (error) {
       assert.strictEqual(error.message, 'idと合致するCommentが見つかりません');
@@ -40,7 +40,7 @@ describe('Comment.deleteCommentのテスト', () => {
   it('適切なid値を送った場合、idと合致するComment一件が返される', () => {
     const validId = { id: 1 };
 
-    const deletedComment = Comment.deleteComment(validId);
+    const deletedComment = Comment.removeComment(validId);
     assert.deepEqual(deletedComment, {
       id: validId.id,
       username: deletedComment.username,
@@ -53,7 +53,7 @@ describe('Comment.deleteCommentのテスト', () => {
     const oldComments = Comment.findAll();
     const validId = { id: 2 };
 
-    Comment.deleteComment(validId);
+    Comment.removeComment(validId);
 
     const currentComments = Comment.findAll();
 


### PR DESCRIPTION
# deleteCommentの作成

`DELETE`リクエストも`PUT`リクエストと同じく`ルートパラメータ`を使用してアドレスの末尾に数字を入力し、その値を受け取りCommentを削除、レスポンス値として返します。
#10 

## メソッド名の修正

今回`deleteComment`を作成するにあたり、前回作成した`models`の`deleteComment`と名前が重複してしまったので、modelsの方を`removeComment`と名前変更しました(これはfixと言うのでしょうか？)

#11 

# deleteCommentのテスト

APIの挙動テストは共通化できそうだったので関数を作成、ステータスコード、id値を引数に設定

## テスト内容
1. 適切でない`id`を送ると400エラーが返る
2. 送られた`id`とひもづく`Comment`がない場合、400エラーが返る
3. 適切なデータを送った場合、`id`とひもづく`Comment`がレスポンス値として返ってくる。
4. `3.`と同時に、配列内にあった`id`とひもづくCommentは配列から削除される。

`4.`のテストは`3.`と共通の`it`内に入れました
