### PR TITLE
return findAll is undefind?

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "codic.case": "camelCase"
+}

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -3,7 +3,7 @@ const Comment = require('../models/Comment');
 module.exports = {
   getComments: (req, res) => {
     const storedComments = Comment.findAll();
-
+    console.log('controllers/comments.js内でのデータ : ', storedComments);
     res.status(200).json(storedComments);
   },
   postComment: (req, res) => {

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -1,31 +1,40 @@
-const dayjs = require('dayjs');
+/* eslint-disable no-undef */
+// const dayjs = require('dayjs');
 
-const comments = [];
+// const comments = [];
 
-let nextId = 1;
+// let nextId = 1;
 
-class Comment {
-  constructor({ username, body }) {
-    this.id = nextId++;
-    this.username = username;
-    this.body = body;
-    this.createdAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
-    this.updatedAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
-  }
-}
+// class Comment {
+//   constructor({ username, body }) {
+//     this.id = nextId++;
+//     this.username = username;
+//     this.body = body;
+//     this.createdAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+//     this.updatedAt = dayjs().format('YYYY年MM月DD日 HH:mm:ss SSS');
+//   }
+// }
 
-// テスト、確認用に配列に挿入するDBの作成
-for (let i = 0; i < 5; i++) {
-  const comment = new Comment({
-    username: 'username' + i,
-    body: 'body' + i,
-  });
-  comments.push(comment);
-}
+// // テスト、確認用に配列に挿入するDBの作成
+// for (let i = 0; i < 5; i++) {
+//   const comment = new Comment({
+//     username: 'username' + i,
+//     body: 'body' + i,
+//   });
+//   comments.push(comment);
+// }
+
+const TodoDatas = require('../config/connect');
 
 module.exports = {
   findAll: () => {
-    return comments.slice();
+    new TodoDatas().fetchAll().then(collection => {
+      const data = {
+        content: collection.toArray(),
+      };
+      console.log('modesls/Comment.js内でのデータ : ', data);
+      return data;
+    });
   },
   createComment: ({ username, body }) => {
     if (!username) {


### PR DESCRIPTION
現在BookShelfというライブラリを使用してDBと接続し、DB内に格納されてあるデータを出力しようとしています。

`./models/Comment.js`の`findAll()`を改造して、DB内のデータを返すようにしました。
この時点では、データは入っています(console.logで確認済み)。

しかし、`./contorollers/comments.js`の`getComments`で、`findAll()`を代入しても`undefind`と出力され、データが無くなっています。

<img width="1231" alt="スクリーンショット 2019-06-17 9 20 45" src="https://user-images.githubusercontent.com/46712701/59571612-8bdbf400-90e1-11e9-8f5f-87ce910b497c.png">

この場合はどこの記述が原因であるか、何か引っかかるポイントがあれば教えていただけたら幸いです